### PR TITLE
updated to match compatability of extensions

### DIFF
--- a/drupal/sites/all/modules/custom/extdir/extdir.module
+++ b/drupal/sites/all/modules/custom/extdir/extdir.module
@@ -59,6 +59,13 @@ function extdir_node_insert($node) {
       break;
     default:
   }
+
+  // Update the compatibility tag to match the newly created release.
+  if ($node->type == 'extension_release_civicrm') {
+    $extension = node_load($node->field_extension_nr_crm[LANGUAGE_NONE][0]['nid']);
+    $extension->field_extension_release_civicrm[LANGUAGE_NONE] = $node->field_extension_release_civicrm[LANGUAGE_NONE];
+    node_save($extension);
+  }
 }
 
 /**
@@ -71,6 +78,13 @@ function extdir_node_update($node) {
       _extdir_flush();
       break;
     default:
+  }
+
+  // Update the compatibility tag to match the updated release.
+  if ($node->type == 'extension_release_civicrm') {
+    $extension = node_load($node->field_extension_nr_crm[LANGUAGE_NONE][0]['nid']);
+    $extension->field_extension_release_civicrm[LANGUAGE_NONE] = $node->field_extension_release_civicrm[LANGUAGE_NONE];
+    node_save($extension);
   }
 }
 


### PR DESCRIPTION
@colemanw could you have a look if this is what you had in mind? I am a bit doubting about whether this is an easy one to do. Because what do we do with the extensions and release already in the database? Should we update the field_extension_release_civicrm of existing extensions? 

And what do we do when a new release is added? Do we overwrite the existing term reference or do we add the new ones? 

My solution is to overwrite the field_extension_release_civicrm of an extension as soon as a release is added or updated. 

btw. I have not really tested the code as I don't have a test environment of the website where I could test the code.