### PR TITLE
Time contributions valued below minimum wage

### DIFF
--- a/drupal/sites/all/modules/custom/civicrm_org_members/civicrm_org_members.module
+++ b/drupal/sites/all/modules/custom/civicrm_org_members/civicrm_org_members.module
@@ -35,7 +35,7 @@ function civicrm_org_members_civicrm_sumfields_definitions(&$custom) {
     'text_length' => '32',
     // Tally all financial contributions, code contributions (type 18) get multiplied
     'trigger_sql' => '(
-      SELECT COALESCE(SUM(IF(cont1.financial_type_id = 18, cont1.total_amount*10, cont1.total_amount)),0)
+      SELECT COALESCE(SUM(IF(cont1.financial_type_id = 18, cont1.total_amount*60, cont1.total_amount)),0)
       FROM civicrm_contribution cont1
       LEFT JOIN civicrm_contribution_soft soft
         ON soft.contribution_id = cont1.id


### PR DESCRIPTION
Adding time contributions to cash contributions is a nice way to solve the problem of valuing the variety of ways that organizations help CiviCRM.  However, assuming that the time tracker form records a $1 contribution for each hour someone enters (as it displays in the total), the sumfield is only valuing those time contributions at $10 per hour.

That's quite low--less than the minimum wage here and many places.

This PR just modifies it to $60 per hour--I took the core team sticker price for members/partners ($125), divided by two, and rounded down.